### PR TITLE
Removed links to github documentation

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,10 +48,6 @@
 			
 			<p>Click <a href="viewWorkouts.php">Here</a> to view your workout history.</p>
 
-			<!-- SUPPORT OR CONTACT -->
-			<h3><a id="support-or-contact" class="anchor" href="#support-or-contact" aria-hidden="true"><span class="octicon octicon-link"></span></a>Support or Contact</h3>
-
-			<p>Having trouble with Pages? Check out our <a href="https://help.github.com/pages">documentation</a> or <a href="https://github.com/contact">contact support</a> and we’ll help you sort it out.</p>
 		</section>
 	</div>
 


### PR DESCRIPTION
Removed the section on support and contact which linked to the github documentation. Was left over from the initial github pages code. 
